### PR TITLE
Refactor game organisation

### DIFF
--- a/@types.lua
+++ b/@types.lua
@@ -1,0 +1,8 @@
+---@class GameData
+---@field title string
+---@field description string
+---@field gameUrl string file path from the games/ directory (including games/)
+---@field icon string file path for the game icon
+---@field banner string unused at this time, only referenced
+---@field size? number simulated size of the app for the phone
+---@field images? string[] array of file paths for app pictures, used in app store

--- a/mfp_lb-games/client/games.lua
+++ b/mfp_lb-games/client/games.lua
@@ -1,12 +1,3 @@
----@class GameData
----@field title string
----@field description string
----@field gameUrl string file path from the games/ directory (including games/)
----@field icon string file path for the game icon
----@field banner string unused at this time, only referenced
----@field size? number simulated size of the app for the phone
----@field images? string[] array of file paths for app pictures, used in app store
-
 Games = {
     {
         title = "1024",

--- a/mfp_lb-games/client/games.lua
+++ b/mfp_lb-games/client/games.lua
@@ -1,3 +1,12 @@
+---@class GameData
+---@field title string
+---@field description string
+---@field gameUrl string file path from the games/ directory (including games/)
+---@field icon string file path for the game icon
+---@field banner string unused at this time, only referenced
+---@field size? number simulated size of the app for the phone
+---@field images? string[] array of file paths for app pictures, used in app store
+
 Games = {
     {
         title = "1024",
@@ -25,7 +34,7 @@ Games = {
         description = "Classic Snake game.",
         gameUrl = "games/snake/index.html",
         icon = "games/snake/snake.png",
-        banner = "games/snake/banner.webp"
+        banner = "games/snake/banner.webp",
     },
     {
         title = "CLASSIC Teetris",
@@ -48,4 +57,4 @@ Games = {
         icon = "games/flappybird/assets/icon.png",
         banner = "games/flappybird/assets/banner.webp"
     }
-}
+} --[[ @as GameData[] ]]

--- a/mfp_lb-games/client/games.lua
+++ b/mfp_lb-games/client/games.lua
@@ -29,7 +29,7 @@ Games = {
     },
     {
         title = "CLASSIC Teetris",
-        description = "Classic Snake game.",
+        description = "Classic Teetris game.",
         gameUrl = "games/teetris/index.html",
         icon = "games/teetris/icon.png",
         banner = "games/teetris/banner.jpg"

--- a/mfp_lb-games/client/games.lua
+++ b/mfp_lb-games/client/games.lua
@@ -1,0 +1,51 @@
+Games = {
+    {
+        title = "1024",
+        description = "Classic 1024 game.",
+        gameUrl = "games/1024/index.html",
+        icon = "games/1024/assets/icon.png",
+        banner = "games/1024/assets/banner.jpg"
+    },
+    {
+        title = "CLASSIC Pac-Man",
+        description = "Classic Pac-Man game.",
+        gameUrl = "games/pacman/pacman.html",
+        icon = "games/pacman/icon.webp",
+        banner = "games/pacman/banner.jpg"
+    },
+    {
+        title = "Tic Tac Toe",
+        description = "Don't win a beer!",
+        gameUrl = "games/tictactoe/index.html",
+        icon = "games/tictactoe/icon.png",
+        banner = "games/tictactoe/banner.png"
+    },
+    {
+        title = "CLASSIC Snake",
+        description = "Classic Snake game.",
+        gameUrl = "games/snake/index.html",
+        icon = "games/snake/snake.png",
+        banner = "games/snake/banner.webp"
+    },
+    {
+        title = "CLASSIC Teetris",
+        description = "Classic Snake game.",
+        gameUrl = "games/teetris/index.html",
+        icon = "games/teetris/icon.png",
+        banner = "games/teetris/banner.jpg"
+    },
+    {
+        title = "CLASSIC Alien Invasion",
+        description = "Classic Alien Invasion game.",
+        gameUrl = "games/alieninvasion/index.html",
+        icon = "games/alieninvasion/assets/icon.jpg",
+        banner = "games/alieninvasion/assets/banner.png"
+    },
+    {
+        title = "Flappy Börd",
+        description = "Classic Flappy Börd game.",
+        gameUrl = "games/flappybird/index.html",
+        icon = "games/flappybird/assets/icon.png",
+        banner = "games/flappybird/assets/banner.webp"
+    }
+}

--- a/mfp_lb-games/client/main.lua
+++ b/mfp_lb-games/client/main.lua
@@ -1,33 +1,43 @@
-local identifier = "mfp_lb-games"
+local function formatIdentifier(title)
+    local formatted = title:lower()
+    formatted = formatted:gsub("[^a-z0-9 ]", "-")
+    return ("mfp-games-%s"):format(title)
+end
+
+local function AddApps()
+    for i = 1, #Games do
+        local game = Games[i]
+        local added, errorMessage = exports["lb-phone"]:AddCustomApp({
+            identifier = formatIdentifier(game.title),
+            name = game.title,
+            description = game.description,
+            developer = "MFPSCRIPTS.com",
+            defaultApp = Config.DefaultApp,
+            size = game.size or Config.Size,
+            images = game.size or {},
+            ui = GetCurrentResourceName() .. "/html/" .. game.gameUrl,
+            icon = "https://cfx-nui-" .. GetCurrentResourceName() .. "/html/" .. game.icon,
+            fixBlur = true
+        })
+
+        if not added then
+            print("Could not add app:", errorMessage)
+        end
+
+        print('Added', game.title)
+    end
+end
 
 CreateThread(function ()
     while GetResourceState("lb-phone") ~= "started" do
         Wait(500)
     end
 
-    local function AddApp()
-        local added, errorMessage = exports["lb-phone"]:AddCustomApp({
-            identifier = identifier,
-            name = Config.AppName,
-            description = Config.Description,
-            developer = "MFPSCRIPTS.com",
-            defaultApp = Config.DefaultApp,
-            size = Config.Size,
-            images = Config.Images,
-            ui = GetCurrentResourceName() .. "/html/index.html",
-            icon = "https://cfx-nui-" .. GetCurrentResourceName() .. "/html/assets/app.jpg"
-        })
-
-        if not added then
-            print("Could not add app:", errorMessage)
-        end
-    end
-
-    AddApp()
+    AddApps()
 
     AddEventHandler("onResourceStart", function(resource)
         if resource == "lb-phone" then
-            AddApp()
+            AddApps()
         end
     end)
 end)

--- a/mfp_lb-games/client/main.lua
+++ b/mfp_lb-games/client/main.lua
@@ -14,7 +14,7 @@ local function AddApps()
             developer = "MFPSCRIPTS.com",
             defaultApp = Config.DefaultApp,
             size = game.size or Config.Size,
-            images = game.size or {},
+            images = game.images or {},
             ui = GetCurrentResourceName() .. "/html/" .. game.gameUrl,
             icon = "https://cfx-nui-" .. GetCurrentResourceName() .. "/html/" .. game.icon,
             fixBlur = true

--- a/mfp_lb-tablet-games/client/games.lua
+++ b/mfp_lb-tablet-games/client/games.lua
@@ -1,12 +1,3 @@
----@class GameData
----@field title string
----@field description string
----@field gameUrl string file path from the games/ directory (including games/)
----@field icon string file path for the game icon
----@field banner string unused at this time, only referenced
----@field size? number simulated size of the app for the phone
----@field images? string[] array of file paths for app pictures, used in app store
-
 Games = {
     {
         title = "1024",

--- a/mfp_lb-tablet-games/client/games.lua
+++ b/mfp_lb-tablet-games/client/games.lua
@@ -1,0 +1,60 @@
+---@class GameData
+---@field title string
+---@field description string
+---@field gameUrl string file path from the games/ directory (including games/)
+---@field icon string file path for the game icon
+---@field banner string unused at this time, only referenced
+---@field size? number simulated size of the app for the phone
+---@field images? string[] array of file paths for app pictures, used in app store
+
+Games = {
+    {
+        title = "1024",
+        description = "Classic 1024 game.",
+        gameUrl = "games/1024/game/game.html",
+        icon = "games/1024/assets/icon.png",
+        banner = "games/1024/assets/banner.jpg"
+    },
+    {
+        title = "CLASSIC Pac-Man",
+        description = "Classic Pac-Man game.",
+        gameUrl = "games/pacman/app/index.html",
+        icon = "games/pacman/icon.webp",
+        banner = "games/pacman/banner.jpg"
+    },
+    {
+        title = "Tic Tac Toe",
+        description = "Don't win a beer!",
+        gameUrl = "games/tictactoe/app/index.html",
+        icon = "games/tictactoe/icon.png",
+        banner = "games/tictactoe/banner.png"
+    },
+    {
+        title = "CLASSIC Snake",
+        description = "Classic Snake game.",
+        gameUrl = "games/snake/app/index.html",
+        icon = "games/snake/snake.png",
+        banner = "games/snake/banner.webp"
+    },
+    {
+        title = "CLASSIC Teetris",
+        description = "Classic Snake game.",
+        gameUrl = "games/teetris/app/index.html",
+        icon = "games/teetris/icon.png",
+        banner = "games/teetris/banner.jpg"
+    },
+    {
+        title = "CLASSIC Alien Invasion",
+        description = "Classic Alien Invasion game.",
+        gameUrl = "games/alieninvasion/game/index.html",
+        icon = "games/alieninvasion/assets/icon.jpg",
+        banner = "games/alieninvasion/assets/banner.png"
+    },
+    {
+        title = "Flappy Börd",
+        description = "Classic Flappy Börd game.",
+        gameUrl = "games/flappybird/index.html",
+        icon = "games/flappybird/assets/icon.png",
+        banner = "games/flappybird/assets/banner.webp"
+    }
+} --[[ @as GameData[] ]]

--- a/mfp_lb-tablet-games/client/main.lua
+++ b/mfp_lb-tablet-games/client/main.lua
@@ -1,33 +1,41 @@
-local identifier = "mfp_lb-tablet_games"
+local function formatIdentifier(title)
+    local formatted = title:lower()
+    formatted = formatted:gsub("[^a-z0-9 ]", "-")
+    return ("mfp-tablet-games-%s"):format(title)
+end
 
-CreateThread(function ()
-    while GetResourceState("lb-tablet") ~= "started" do
-        Wait(500)
-    end
-
-    local function AddApp()
+local function AddApps()
+    for i = 1, #Games do
+        local game = Games[i]
         local added, errorMessage = exports["lb-tablet"]:AddCustomApp({
-            identifier = identifier,
-            name = Config.AppName,
-            description = Config.Description,
+            identifier = formatIdentifier(game.title),
+            name = game.title,
+            description = game.description,
             developer = "MFPSCRIPTS.com",
             defaultApp = Config.DefaultApp,
-            size = Config.Size,
-            images = Config.Images,
-            ui = "html/index.html", -- ✅ Wichtig!
-            icon = "https://cfx-nui-" .. GetCurrentResourceName() .. "/html/assets/app.jpg" -- ✅ Richtig aufbauen
+            size = game.size or Config.Size,
+            images = game.images or {},
+            ui = "https://cfx-nui-" .. GetCurrentResourceName() .. "/html/" .. game.gameUrl,
+            icon = "https://cfx-nui-" .. GetCurrentResourceName() .. "/html/" .. game.icon,
+            fixBlur = true
         })
 
         if not added then
             print("Could not add app:", errorMessage)
         end
     end
+end
 
-    AddApp()
+CreateThread(function ()
+    while GetResourceState("lb-tablet") ~= "started" do
+        Wait(500)
+    end
+
+    AddApps()
 
     AddEventHandler("onResourceStart", function(resource)
         if resource == "lb-tablet" then
-            AddApp()
+            AddApps()
         end
     end)
 end)


### PR DESCRIPTION
This PR refactors the current game switching mechanism to improve flexibility and maintainability.

### Changes:

* **Removed** usage of `window.location.href` for switching games, which previously caused full page reloads and prevented seamless transitions.
* **Implemented** a modular app system where each game is treated as a standalone app.

  * These apps are now switched using the same routing mechanism already in use within the platform.
* **Added** a Lua table definition to manage the list of available apps, simplifying the process of adding or modifying games in the future.

This change lays the groundwork for more dynamic and scalable game integration without sacrificing user experience.

### Extra notes:
- This now makes the root index.html no longer used in game, however it stays a required piece as far as I know to be able to render the subsequent games, it can however be altered as a simple dev tool.
- Certain CSS can be broken, didn't test all games in game
